### PR TITLE
Fixing statements in core.py not compatible with Python < 3.9

### DIFF
--- a/recommender/core.py
+++ b/recommender/core.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Union
 from pymatgen.core import Structure, Element
 from pymatgen.analysis.structure_matcher import StructureMatcher
@@ -395,7 +396,7 @@ class RecommenderSystem:
                         else:
                             return False
 
-    def get_recommendation_for_ion(self, ion: str, top_n: int = None, only_new: bool = False, local_geometry: tuple = None) -> list([tuple([str, AMSite, bool])]):
+    def get_recommendation_for_ion(self, ion: str, top_n: int = None, only_new: bool = False, local_geometry: tuple = None) -> list[tuple[str, AMSite, bool]]:
         """
         Generate a list of site recommendations for a given ion.
 
@@ -455,7 +456,7 @@ class RecommenderSystem:
 
         return recommendation_list
 
-    def get_recommendation_for_site(self, site: str, top_n: int = None, only_new: bool = False) -> list([tuple([str, float, bool])]):
+    def get_recommendation_for_site(self, site: str, top_n: int = None, only_new: bool = False) -> list[tuple[str, float, bool]]:
         """
         Generate a list of ion recommendations for a given site.
 
@@ -502,7 +503,7 @@ class RecommenderSystem:
 
         return recommendation_list
 
-    def get_recommendation_for_AM(self, AM: AnonymousMotif) -> dict(AMSite = list([tuple([str, float, bool])])):
+    def get_recommendation_for_AM(self, AM: AnonymousMotif) -> dict[AMSite, list[tuple[str, float, bool]]]:
         """
         Generate a dictionary of ion recommendations for each site of an Anonymous Motif (AM).
 

--- a/recommender/core.py
+++ b/recommender/core.py
@@ -395,7 +395,7 @@ class RecommenderSystem:
                         else:
                             return False
 
-    def get_recommendation_for_ion(self, ion: str, top_n: int = None, only_new: bool = False, local_geometry: tuple = None) -> list[tuple[str, AMSite, bool]]:
+    def get_recommendation_for_ion(self, ion: str, top_n: int = None, only_new: bool = False, local_geometry: tuple = None) -> list([tuple([str, AMSite, bool])]):
         """
         Generate a list of site recommendations for a given ion.
 
@@ -455,7 +455,7 @@ class RecommenderSystem:
 
         return recommendation_list
 
-    def get_recommendation_for_site(self, site: str, top_n: int = None, only_new: bool = False) -> list[tuple[str, float, bool]]:
+    def get_recommendation_for_site(self, site: str, top_n: int = None, only_new: bool = False) -> list([tuple([str, float, bool])]):
         """
         Generate a list of ion recommendations for a given site.
 
@@ -502,7 +502,7 @@ class RecommenderSystem:
 
         return recommendation_list
 
-    def get_recommendation_for_AM(self, AM: AnonymousMotif) -> dict[AMSite, list[tuple[str, float, bool]]]:
+    def get_recommendation_for_AM(self, AM: AnonymousMotif) -> dict(AMSite = list([tuple([str, float, bool])])):
         """
         Generate a dictionary of ion recommendations for each site of an Anonymous Motif (AM).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python 3.7+
 pymatgen
 gensim
 joblib


### PR DESCRIPTION
Statements in `core.py` like `list[tuple[str,...]]` are not compatible with Python < 3.9. A fix for Python 3.7 and 3.8 is to import `__future__.annotations`. Also added `python 3.7+` to requirements.txt.

Note: Tested this solution on Python 3.8.5. Didn't check it fails for Python < 3.7. Based the above statements on this stack overflow [question](https://stackoverflow.com/questions/63460126/typeerror-type-object-is-not-subscriptable-in-a-function-signature).